### PR TITLE
Send events directly instead of allocating `Vec`

### DIFF
--- a/crates/bevy_winit/src/winit_event.rs
+++ b/crates/bevy_winit/src/winit_event.rs
@@ -1,6 +1,5 @@
 #![allow(missing_docs)]
 
-use bevy_app::App;
 use bevy_ecs::prelude::*;
 use bevy_input::keyboard::KeyboardInput;
 use bevy_input::touch::TouchInput;
@@ -185,93 +184,4 @@ impl From<KeyboardInput> for WinitEvent {
     fn from(e: KeyboardInput) -> Self {
         Self::KeyboardInput(e)
     }
-}
-
-/// Forwards buffered [`WinitEvent`] events to the app.
-pub(crate) fn forward_winit_events(buffered_events: &mut Vec<WinitEvent>, app: &mut App) {
-    if buffered_events.is_empty() {
-        return;
-    }
-    for winit_event in buffered_events.iter() {
-        match winit_event.clone() {
-            WinitEvent::ApplicationLifetime(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::CursorEntered(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::CursorLeft(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::CursorMoved(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::FileDragAndDrop(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::Ime(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::ReceivedCharacter(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::RequestRedraw(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowBackendScaleFactorChanged(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowCloseRequested(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowCreated(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowDestroyed(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowFocused(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowMoved(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowOccluded(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowResized(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowScaleFactorChanged(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::WindowThemeChanged(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::MouseButtonInput(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::MouseMotion(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::MouseWheel(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::TouchpadMagnify(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::TouchpadRotate(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::TouchInput(e) => {
-                app.world.send_event(e);
-            }
-            WinitEvent::KeyboardInput(e) => {
-                app.world.send_event(e);
-            }
-        }
-    }
-    app.world
-        .resource_mut::<Events<WinitEvent>>()
-        .send_batch(buffered_events.drain(..));
 }


### PR DESCRIPTION
Suggested change that avoids reallocating a`Vec` and dispatching events separately, and instead sends events into the app as they are received.